### PR TITLE
fix: configure pymdownx.tabbed so that content tabs work

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -116,7 +116,8 @@ markdown_extensions:
           class: mermaid
           format: !!python/name:pymdownx.superfences.fence_code_format
   - pymdownx.snippets
-  - pymdownx.tabbed
+  - pymdownx.tabbed:
+      alternate_style: true
   - pymdownx.tilde
   - pymdownx.betterem:
       smart_enable: all


### PR DESCRIPTION
Hey, awesome template!
I found out that Content Tabs weren't working with the default config. They also aren't currently working in your demo (https://abolfazlamiri.ir/gruvdoc/demo/content-tabs/).

I fixed the problem by configuring pymdownx.tabbed with the alternate_style option set to true like in the mkdocs-material docs (https://squidfunk.github.io/mkdocs-material/reference/content-tabs/).

